### PR TITLE
Add compiler flag to suppress integer to pointer conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,26 +11,33 @@ The right RISC-V GCC toolchain can be built [here](https://github.com/riscv-coll
 
 To build and run your wiringX application on a Milk-V Duo Linux environment follow those steps:
 
-1. Boot the Duo and connect to it using ssh using ```ssh root@192.168.42.1``` with password `milkv`.
+1. Boot the Duo and connect to it using ssh using `ssh root@192.168.42.1` with password `milkv`.
    You can also run the `ssh-copy-id root@192.168.42.1` command to export your ssh key to the Duo.
 
-2. On your Duo run ```ln -s /lib/ld-musl-riscv64v0p7_xthead.so.1 /lib/ld-musl-riscv64.so.1``` for the programs to work.
+2. On your Duo run `ln -s /lib/ld-musl-riscv64v0p7_xthead.so.1 /lib/ld-musl-riscv64.so.1` for the programs to work.
 
 3. Install the [riscv-gnu-toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain), run the `configure` script with all default settings and no flags,
-   then run ```sudo make musl```
-   
-4. Open your `~/.cargo/config.toml` and add this to make it compile: 
+   then run `sudo make musl`
+
+4. Open your `~/.cargo/config.toml` and add this to make it compile:
+
 ```toml
 [target.riscv64gc-unknown-linux-musl]
 linker = "riscv64-unknown-linux-musl-gcc"
 rustflags = ["-C", "target-feature=-crt-static"]
-``` 
-   
+```
+
+> Your `sysroot` path may need to be declared
+>
+> ```
+> export BINDGEN_EXTRA_CLANG_ARGS='--sysroot /path/to/toolchain/sysroot/'
+> ```
+
 5. Compile your Rust program to the `riscv64gc-unknown-linux-musl` architecture using wiringX in Rust using the nightly
    toolchain and build-std flags to unlock the standard library using this specific command:
-```cargo +nightly build --release --target=riscv64gc-unknown-linux-musl -Zbuild-std=std,core```
+   `cargo +nightly build --release --target=riscv64gc-unknown-linux-musl -Zbuild-std=std,core`
 
-6. If the program has successfully compiled, scp it to your Duo using ```scp -O target/riscv64gc-unknown-linux-musl/release/"binary_name" root@192.168.42.1:```
+6. If the program has successfully compiled, scp it to your Duo using `scp -O target/riscv64gc-unknown-linux-musl/release/"binary_name" root@192.168.42.1:`
 
 Do not forget to replace the "binary_name" with the actual name of your binary.
 

--- a/wiringx-sys/build.rs
+++ b/wiringx-sys/build.rs
@@ -64,6 +64,7 @@ fn main() {
     build.flag("-Wl,-rpath=/usr/local/lib/");
     build.flag("-Wl,-rpath=/usr/lib/");
     build.flag("-Wl,-rpath=/lib/");
+    build.flag("-Wno-int-conversion");
 
     build.flag_if_supported("-w");
 


### PR DESCRIPTION
I recently built riscv-gnu-toolchain for cross compilation with gcc 14.2.0 due to build issues. See https://github.com/riscv-collab/riscv-gnu-toolchain/issues/1536

This change was needed to prevent multiple warnings and subsequently a failing build.

I also needed to declare the `sysroot` directory for bindgen to find the header files required to build wiringx. I am currently declaring this like so:
```sh
export BINDGEN_EXTRA_CLANG_ARGS='--sysroot /opt/riscv/sysroot'
```